### PR TITLE
When filtering data, also exclude any empty rows - done by checking if bib number isn't blank

### DIFF
--- a/sodteamscores/index.html
+++ b/sodteamscores/index.html
@@ -205,7 +205,7 @@ console.log("girls data", girlsData);
 		// Function to filter data by gender and valid race times
 		function filterData(data) {
 			return data.filter(row => {
-				return row['Combined Time'] !== '';
+				return row['Bib'] !== '' && row['Combined Time'] !== '';
 			});
 		}
 


### PR DESCRIPTION
SplitSecond includes an empty blank trailing row on exports, not sure why, but it caused an extra team to be calculated with the name "undefined".